### PR TITLE
:alphanumberic method

### DIFF
--- a/lib/mongoid_token.rb
+++ b/lib/mongoid_token.rb
@@ -43,7 +43,7 @@ module Mongoid
       def generate_token(length, characters)
         case characters
         when :alphanumeric
-          ActiveSupport::SecureRandom.hex(length)[0...length]
+          (1..length).collect { (i = Kernel.rand(62); i += ((i < 10) ? 48 : ((i < 36) ? 55 : 61 ))).chr }.join
         when :numeric
           rand(10**length).to_s
         when :fixed_numeric


### PR DESCRIPTION
Old method include only 'a'..'f' lowercase literals and digits, not more.
New method include [a-zA-z0-9].
See http://snippets.dzone.com/posts/show/2111
