### PR TITLE
InstanceMethods is no longer supported by ActiveSupport::Concern.

### DIFF
--- a/lib/mongoid_token.rb
+++ b/lib/mongoid_token.rb
@@ -33,59 +33,57 @@ module Mongoid
       end
     end
 
-    module InstanceMethods
-      def to_param
-        self.token
-      end
+    def to_param
+      self.token
+    end
 
-      protected
-      def create_token(length, characters)
-        self.token = self.generate_token(length, characters)
-        @generated_token = true
-      end
+    protected
+    def create_token(length, characters)
+      self.token = self.generate_token(length, characters)
+      @generated_token = true
+    end
 
-      def validate_token_uniqueness!(length, characters, attempts)
-        if !defined?(@testing_uniqueness) && defined?(@generated_token)
-          attempts_remaining = attempts
-          @testing_uniqueness = true
-          while attempts_remaining > 0 && @testing_uniqueness
-            begin
-              self.safely.save
-              @testing_uniqueness = false
-            rescue Exception => e
-              if defined?(Rails) && Rails.env == 'development'
-                Rails.logger.warn "[Mongoid::Token] Warning: Duplicate token found, recreating."
-              end
-              attempts_remaining -= 1
-              create_token(length, characters)
+    def validate_token_uniqueness!(length, characters, attempts)
+      if !defined?(@testing_uniqueness) && defined?(@generated_token)
+        attempts_remaining = attempts
+        @testing_uniqueness = true
+        while attempts_remaining > 0 && @testing_uniqueness
+          begin
+            self.safely.save
+            @testing_uniqueness = false
+          rescue Exception => e
+            if defined?(Rails) && Rails.env == 'development'
+              Rails.logger.warn "[Mongoid::Token] Warning: Duplicate token found, recreating."
             end
-          end
-
-          unless attempts_remaining > 0
-            raise Mongoid::Token::CollisionRetriesExceeded.new(self, attempts) unless attempts_remaining > 0
+            attempts_remaining -= 1
+            create_token(length, characters)
           end
         end
-      end
 
-      def token_unique?
-        self.class.exists?(:conditions => {:token => self.token})
-      end
-
-      def create_token_if_nil(length, characters)
-        self.create_token(length, characters) if self.token.nil?
-      end
-
-      def generate_token(length, characters = :alphanumeric)
-        case characters
-        when :alphanumeric
-          (1..length).collect { (i = Kernel.rand(62); i += ((i < 10) ? 48 : ((i < 36) ? 55 : 61 ))).chr }.join
-        when :numeric
-          rand(10**length).to_s
-        when :fixed_numeric
-          rand(10**length).to_s.rjust(length,rand(10).to_s)
-        when :alpha
-          Array.new(length).map{['A'..'Z','a'..'z'].map{|r|r.to_a}.flatten[rand(52)]}.join
+        unless attempts_remaining > 0
+          raise Mongoid::Token::CollisionRetriesExceeded.new(self, attempts) unless attempts_remaining > 0
         end
+      end
+    end
+
+    def token_unique?
+      self.class.exists?(:conditions => {:token => self.token})
+    end
+
+    def create_token_if_nil(length, characters)
+      self.create_token(length, characters) if self.token.nil?
+    end
+
+    def generate_token(length, characters = :alphanumeric)
+      case characters
+      when :alphanumeric
+        (1..length).collect { (i = Kernel.rand(62); i += ((i < 10) ? 48 : ((i < 36) ? 55 : 61 ))).chr }.join
+      when :numeric
+        rand(10**length).to_s
+      when :fixed_numeric
+        rand(10**length).to_s.rjust(length,rand(10).to_s)
+      when :alpha
+        Array.new(length).map{['A'..'Z','a'..'z'].map{|r|r.to_a}.flatten[rand(52)]}.join
       end
     end
   end


### PR DESCRIPTION
Rails 3.2 removed support for the InstanceMethods module, since it's completely unnecessary.
