### PR TITLE
Add :fixed_numeric_not_null

### DIFF
--- a/lib/mongoid_token.rb
+++ b/lib/mongoid_token.rb
@@ -94,6 +94,8 @@ module Mongoid
         rand(10**length).to_s
       when :fixed_numeric
         rand(10**length).to_s.rjust(length,rand(10).to_s)
+      when :fixed_numeric_not_null
+        (rand(10**length - 10**(length-1)) + 10**(length-1)).to_s
       when :alpha
         Array.new(length).map{['A'..'Z','a'..'z'].map{|r|r.to_a}.flatten[rand(52)]}.join
       end

--- a/spec/mongoid/token_spec.rb
+++ b/spec/mongoid/token_spec.rb
@@ -37,6 +37,14 @@ class Video
   token :length => 8, :contains => :alpha, :field_name => :vid
 end
 
+class Image
+  include Mongoid::Document
+  include Mongoid::Token
+
+  field :url
+  token :length => 8, :contains => :fixed_numeric_not_null
+end
+
 class Node
   include Mongoid::Document
   include Mongoid::Token
@@ -60,11 +68,13 @@ describe Mongoid::Token do
     @account = Account.create(:name => "Involved Pty. Ltd.")
     @link = Link.create(:url => "http://involved.com.au")
     @video = Video.create(:name => "Nyan nyan")
+    @image = Image.create(:url => "http://involved.com.au/image.png")
 
     Account.create_indexes
     Link.create_indexes
     FailLink.create_indexes
     Video.create_indexes
+    Image.create_indexes
     Node.create_indexes
   end
 
@@ -78,6 +88,7 @@ describe Mongoid::Token do
     @account.token.length.should == 16
     @link.token.length.should == 3
     @video.vid.length.should == 8
+    @image.token.length.should == 8
   end
 
   it "should only generate unique tokens" do
@@ -189,6 +200,15 @@ describe Mongoid::Token do
     @cluster.nodes.each do |node|
       node.attributes.include?('token').should == true
       node.token.match(/[0-9]{8}/).should_not == nil
+    end
+  end
+
+  describe "with :fixed_numeric_not_null" do
+    it "should not start with 0" do
+      1000.times do
+        image = Image.create(:url => "something")
+        image.token.should_not start_with "0"
+      end
     end
   end
 end


### PR DESCRIPTION
I created a new option for `contains`: `:fixed_numeric_not_null`

It does the same thing as `:fixed_numeric`, but does not generate numbers that starts with a zero. I'm unsure of the naming of the option - rename it as you see fit. :)

For example, if length is set to 5, it will generate numbers between 10000 and 99999.
