### PR TITLE
Added static string prefix option for token

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ You can also rename the token field, if required, using the
 
 * `token :contains => :numeric, :field_name => :purchase_order_number`
 
+You can add a prefix to the generated token using the
+`:prefix` option (length doesn't include prefix):
+
+* `token :contains => :numeric, :length => 4, :prefix => 'TST-'`  =>  `TST-0123`
+
+
 ### Examples:
 
 * `token :length => 8, :contains => :alphanumeric` generates something like `8Sdc98dQ`


### PR DESCRIPTION
My project has the requirement that mongoid_tokens be generated for several different mongo collections. So, we need a way to differentiate between them (both in the system and for users). I've added support for a static prefix string option that is prepended to the token after generation. It is stored with the token, but not considered for the length option.

`token :contains => :numeric, :length => 4, :prefix => 'TST-'`
`"TST-0123"`

Additional specs were added to cover the new option.
