### PR TITLE
Call define_method using send, instead of directly (fixes 1.9.3 compatibility)

### DIFF
--- a/lib/mongoid/token.rb
+++ b/lib/mongoid/token.rb
@@ -38,7 +38,7 @@ module Mongoid
         end
 
         if options.override_to_param?
-          self.define_method :to_param do
+          self.send(:define_method, :to_param) do
             self.send(options.field_name) || super
           end
         end

--- a/lib/mongoid/token/collision_resolver.rb
+++ b/lib/mongoid/token/collision_resolver.rb
@@ -25,7 +25,7 @@ module Mongoid
       private
       def alias_method_with_collision_resolution(method)
         handler = self
-        klass.define_method(:"#{method.to_s}_with_#{handler.field_name}_safety") do |method_options = {}|
+        klass.send(:define_method, :"#{method.to_s}_with_#{handler.field_name}_safety") do |method_options = {}|
           self.resolve_token_collisions handler do
             with(:safe => true).send(:"#{method.to_s}_without_#{handler.field_name}_safety", method_options)
           end


### PR DESCRIPTION
Looks like this bug was fixed in Ruby 2, but I am using 1.9.3.

Works around https://bugs.ruby-lang.org/issues/8284
Makes tests pass on 1.9.3.
