### PR TITLE
Added support for tokens replacing default the `_id` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,19 +60,17 @@ in your app
 
 ## Finders
 
-**Note: overriding of the `find` method has been deprecated in this
-version and will be removed in the next major release.**
+By default, the gem will add a convenience `find_by_[token name]` method, to
+make it a tiny bit simpler to query by your tokens. If you'd rather it didn't,
+you can disable these with the
+[`skip_finders` configuration option](#skip-finders-skip_finders).
 
-By default, the gem will override the existing `find` method in Mongoid,
-in order to search for documents based on their token first (although
-the default behaviour of ObjectIDs is also there). You can disable these
-with the [`skip_finders` configuration option](#skip-finders-skip_finders).
+The methods accept either a single token, or an array of tokens:
 
 ```ruby
-Video.find("x3v98")
-Account.find("ACC-123456")
+Video.find_by_token("x3v98") # If your token was named 'token'
+Account.find_by_account_number(["ACC-123456", "ACC-567890"]) # If your token was named 'account_number'
 ```
-
 
 ## Configuration
 
@@ -184,8 +182,7 @@ token :field_name => :yet_another
 
 ### Skip Finders (`:skip_finders`)
 
-This will prevent the gem from creating the customised finders and
-overrides for the default `find` behaviour used by Mongoid.
+This will prevent the gem from creating the extra `find_by_*` methods.
 
 __Example:__
 ```ruby

--- a/lib/mongoid/token.rb
+++ b/lib/mongoid/token.rb
@@ -20,14 +20,14 @@ module Mongoid
         add_token_field_and_index(options)
         add_token_collision_resolver(options)
         set_token_callbacks(options)
-        
+
         define_custom_finders(options) if options.skip_finders? == false
         override_to_param(options) if options.override_to_param?
       end
 
       private
       def add_token_field_and_index(options)
-        self.field options.field_name, :type => String, :default => nil
+        self.field options.field_name, :type => String, :default => default_value(options)
         self.index({ options.field_name => 1 }, { :unique => true, :sparse => true })
       end
 
@@ -56,6 +56,10 @@ module Mongoid
         self.send(:define_method, :to_param) do
           self.send(options.field_name) || super()
         end
+      end
+
+      def default_value(options)
+        options.generate_on_init && Mongoid::Token::Generator.generate(options.pattern) || nil
       end
     end
 

--- a/lib/mongoid/token/finders.rb
+++ b/lib/mongoid/token/finders.rb
@@ -9,15 +9,6 @@ module Mongoid
             self.find_by field_name.to_sym => token
           end
         end
-
-        klass.define_singleton_method :"find_with_#{field_name}" do |*args| # this is going to be painful if tokens happen to look like legal object ids
-          warn "[DEPRECATION] Using `find' from Mongoid::Token has been deprecated and will be removed in version 3.0.0."
-          args.all?{|arg| BSON::ObjectId.legal?(arg)} ? send(:"find_without_#{field_name}",*args) : klass.send(:"find_by_#{field_name.to_s}", args.first)
-        end
-
-        # this craziness taken from, and then compacted into a string class_eval
-        # http://geoffgarside.co.uk/2007/02/19/activesupport-alias-method-chain-modules-and-class-methods/
-        klass.class_eval("class << self; alias_method_chain :find, :#{field_name} if self.method_defined?(:find); end")
       end
     end
   end

--- a/lib/mongoid/token/options.rb
+++ b/lib/mongoid/token/options.rb
@@ -16,7 +16,7 @@ class Mongoid::Token::Options
   end
 
   def field_name
-    @options[:field_name]
+    !@options[:id] && @options[:field_name] || :_id
   end
 
   def skip_finders?
@@ -25,6 +25,10 @@ class Mongoid::Token::Options
 
   def override_to_param?
     @options[:override_to_param]
+  end
+
+  def generate_on_init
+    @options[:id] || @options[:generate_on_init]
   end
 
   def pattern
@@ -61,12 +65,14 @@ class Mongoid::Token::Options
 
   def merge_defaults(options)
     {
-      :length => 4,
-      :retry_count => 3,
-      :contains => :alphanumeric,
-      :field_name => :token,
-      :skip_finders => false,
-      :override_to_param => true,
+      id: false,
+      length: 4,
+      retry_count: 3,
+      contains: :alphanumeric,
+      field_name: :token,
+      skip_finders: false,
+      override_to_param: true,
+      generate_on_init: false
     }.merge(options)
   end
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module MongoidToken
-  VERSION = "2.2.0"
+  VERSION = "3.0.0"
 end

--- a/spec/mongoid/token/options_spec.rb
+++ b/spec/mongoid/token/options_spec.rb
@@ -67,4 +67,36 @@ describe Mongoid::Token::Options do
       expect(Mongoid::Token::Options.new.skip_finders?).to eq false
     end
   end
+
+  describe "id" do
+    context "when true" do
+      it "returns '_id' sa the field name" do
+        expect(Mongoid::Token::Options.new({id: true, field_name: :a_token}).field_name).to eq :_id
+      end
+    end
+
+    context "when false" do
+      it "returns the field_name option as the field name" do
+        expect(Mongoid::Token::Options.new({id: false, field_name: :a_token}).field_name).to eq :a_token
+      end
+    end
+  end
+
+  describe :generate_on_init do
+    it "defaults to false" do
+      expect(Mongoid::Token::Options.new({}).generate_on_init).to eq false
+    end
+
+    context "when id option set" do
+      it "is true" do
+        expect(Mongoid::Token::Options.new({id: true}).generate_on_init).to eq true
+      end
+    end
+
+    context "when id option is not set" do
+      it "is false" do
+        expect(Mongoid::Token::Options.new({id: false}).generate_on_init).to eq false
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Added new `id` option
* Added new `generate_on_init` option
* Added test coverage for id overrides
* Removed `find` monkey patches.
* Removed references to monkey patches in README
* Version bumped to 3.0.0

Closes #8