### PR TITLE
remove deprecated option

### DIFF
--- a/lib/mongoid/token/collision_resolver.rb
+++ b/lib/mongoid/token/collision_resolver.rb
@@ -27,7 +27,7 @@ module Mongoid
         handler = self
         klass.send(:define_method, :"#{method.to_s}_with_#{handler.field_name}_safety") do |method_options = {}|
           self.resolve_token_collisions handler do
-            with(:safe => true).send(:"#{method.to_s}_without_#{handler.field_name}_safety", method_options)
+            with.send(:"#{method.to_s}_without_#{handler.field_name}_safety", method_options)
           end
         end
         klass.alias_method_chain method.to_sym, :"#{handler.field_name}_safety"


### PR DESCRIPTION
This option is no longer relevant and creates warnings in mongo logger.
