### PR TITLE
Use :write concern format over :safe which is not valid since Mongoid 4.0.0

### DIFF
--- a/lib/mongoid/token/collision_resolver.rb
+++ b/lib/mongoid/token/collision_resolver.rb
@@ -27,7 +27,7 @@ module Mongoid
         handler = self
         klass.send(:define_method, :"#{method.to_s}_with_#{handler.field_name}_safety") do |method_options = {}|
           self.resolve_token_collisions handler do
-            with(:safe => true).send(:"#{method.to_s}_without_#{handler.field_name}_safety", method_options)
+            with(write: { w: 1 }).send(:"#{method.to_s}_without_#{handler.field_name}_safety", method_options)
           end
         end
         klass.alias_method_chain method.to_sym, :"#{handler.field_name}_safety"


### PR DESCRIPTION
Since upgrading to Mongoid 4.0.0 the :safe option is no longer valid, instead :write should be used. 

This change introduces :write with corresponding propagation semantics. 

CHANGELOG for 4.0.0
https://github.com/mongodb/mongoid/blob/master/CHANGELOG.md#400 
