### PR TITLE
Add option to skip creating the default index on the token attribute.

### DIFF
--- a/lib/mongoid/token.rb
+++ b/lib/mongoid/token.rb
@@ -17,7 +17,8 @@ module Mongoid
       def token(*args)
         options = Mongoid::Token::Options.new(args.extract_options!)
 
-        add_token_field_and_index(options)
+        add_token_field(options)
+        add_index(options)
         add_token_collision_resolver(options)
         set_token_callbacks(options)
 
@@ -26,9 +27,12 @@ module Mongoid
       end
 
       private
-      def add_token_field_and_index(options)
+      def add_token_field(options)
         self.field options.field_name, :type => String, :default => default_value(options)
-        self.index({ options.field_name => 1 }, { :unique => true, :sparse => true })
+      end
+
+      def add_index(options)
+        self.index({ options.field_name => 1 }, { :unique => true, :sparse => true }) unless options.skip_index?
       end
 
       def add_token_collision_resolver(options)

--- a/lib/mongoid/token/options.rb
+++ b/lib/mongoid/token/options.rb
@@ -23,6 +23,10 @@ class Mongoid::Token::Options
     @options[:skip_finders]
   end
 
+  def skip_index?
+    @options[:skip_index]
+  end
+
   def override_to_param?
     @options[:override_to_param]
   end
@@ -71,6 +75,7 @@ class Mongoid::Token::Options
       contains: :alphanumeric,
       field_name: :token,
       skip_finders: false,
+      skip_index: false,
       override_to_param: true,
       generate_on_init: false
     }.merge(options)

--- a/mongoid_token.gemspec
+++ b/mongoid_token.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = %q{Mongoid token is a gem for creating random, unique tokens for mongoid documents. Highly configurable and great for making URLs a little more compact.}
 
   s.rubyforge_project = "mongoid_token"
-  s.add_dependency 'mongoid', '~> 5.0.0'
+  s.add_dependency 'mongoid', '>= 5.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/mongoid/token/options_spec.rb
+++ b/spec/mongoid/token/options_spec.rb
@@ -68,6 +68,16 @@ describe Mongoid::Token::Options do
     end
   end
 
+   describe "skip_index" do
+    it "should be an option" do
+      expect(Mongoid::Token::Options.new({:skip_index => true}).skip_index?).to eq true
+    end
+
+    it "should default to false" do
+      expect(Mongoid::Token::Options.new.skip_index?).to eq false
+    end
+  end
+
   describe "id" do
     context "when true" do
       it "returns '_id' sa the field name" do


### PR DESCRIPTION
Motivation for this is if you are putting the token on an embedded document mongoid gives a warning and will not apply it anyway, so I have one correctly defined on the root object.  You may also want to specify custom parameters in the index (ie. sparse or whatever) this gives you the freedom to do it if you want.
